### PR TITLE
Updates unit test environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,8 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: attackhelicopter/webdriver
-      
+      - image: attackhelicopter/webdriver:0.2.0
+
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
@@ -20,7 +20,7 @@ jobs:
       LEIN_ROOT: "true"
       # Customize the JVM maximum heap limit
       JVM_OPTS: -Xmx3200m
-    
+
     steps:
       - checkout
 
@@ -37,6 +37,6 @@ jobs:
           paths:
             - ~/.m2
           key: v1-dependencies-{{ checksum "project.clj" }}
-        
+
       # run tests!
       - run: lein test

--- a/README.md
+++ b/README.md
@@ -39,5 +39,9 @@ etc...
 
 core.clj contains functions to handle common browser tasks. You can either read through that or checkout tests/webdriver/core_test.clj for unit test examples.
 
+## Tested versions of firefox and chrome
+- Firefox: 61.0.1
+- Google Chrome 68.0.3440.106
+
 ## Known issues
 - chromedriver does not handle alerts properly when headless


### PR DESCRIPTION
attackhelicopter/webdriver:0.2.0 has been released. It contains firefox
61.0.1 and google-chrome 68.0.3440.106. So config.yml for circle ci has
been updated so we are getting unit test results from those newer
browser versions.