### PR TITLE
Adds poll-interval option to wait-for-element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This change
 ## [0.6.0 -2018-10-26]
 ### Added
 - with-webdriver: a macro to replace with-driver with better syntax
+- poll-interval option for wait-for-element
 
 ## [0.5.3 - 2018-09-21]
 ### Changed

--- a/src/webdriver/core.clj
+++ b/src/webdriver/core.clj
@@ -1,8 +1,10 @@
 (ns webdriver.core
   (:gen-class)
   (:import
+    [java.util.concurrent TimeUnit]
     [org.openqa.selenium.remote RemoteWebDriver]
-    [org.openqa.selenium WebElement])
+    [org.openqa.selenium WebElement]
+    [org.openqa.selenium.support.ui WebDriverWait ExpectedConditions])
   (:require [webdriver.driver-manager :as dm]
             [komcrad-utils.wait :refer [wait-for]]
             [clojure.java.io :as io]))
@@ -172,11 +174,14 @@
   (.implicitlyWait (.timeouts (.manage driver)) timeout (java.util.concurrent.TimeUnit/SECONDS)))
 
 (defn wait-for-element
-  "Explicitly waits for element to be clickable with a timeout of max-wait (seconds)"
+  "Explicitly waits for element to be clickable with a timeout of max-wait (seconds)
+   and a poll-interval (milliseconds)"
+  ([driver lookup-type lookup-string max-wait poll-interval]
+   (-> (new WebDriverWait driver max-wait)
+       (.pollingEvery poll-interval (TimeUnit/MILLISECONDS))
+       (.until (. ExpectedConditions elementToBeClickable (by lookup-type lookup-string)))))
   ([driver lookup-type lookup-string max-wait]
-    (. (new org.openqa.selenium.support.ui.WebDriverWait driver max-wait) until
-       (. org.openqa.selenium.support.ui.ExpectedConditions elementToBeClickable
-          (by lookup-type lookup-string))))
+   (wait-for-element driver lookup-type lookup-string max-wait 500))
   ([driver lookup-type lookup-string]
    (wait-for-element driver lookup-type lookup-string 10)))
 

--- a/test/webdriver/core_test.clj
+++ b/test/webdriver/core_test.clj
@@ -145,7 +145,13 @@
       (is (= "potato") (get-element-value (wait-for-element driver :id "input2" 5) :value))
       (click driver :id "btn3")
       (click driver :id "btn2")
-      (is (= "potato") (get-element-value (wait-for-element driver :id "input2") :value)))))
+      (is (= "potato") (get-element-value (wait-for-element driver :id "input2") :value))
+      (is (thrown? Exception
+                   (wait-for-element driver :id "notanelement" 0 500)))
+      (let [start-time (System/currentTimeMillis)]
+        (is (thrown? Exception
+                     (wait-for-element driver :id "notanelement" 1 1200)))
+        (is (< 1200 (- (System/currentTimeMillis) start-time)))))))
 
 (deftest ^:parallel wait-elm-dom-test
   (testing "wait-elm-dom"


### PR DESCRIPTION
Now you can specify a smaller or larger polling interval for waiting on
elments to be clickable. Default has always been 500 milliseconds (that
comes from selenium).