### PR TITLE
Updates docker image to use for circleci 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: attackhelicopter/webdriver:0.7.0
+      - image: attackhelicopter/webdriver:0.8.0
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ core.clj contains functions to handle common browser tasks. You can either read 
 
 ## Tested versions of firefox and chrome
 - webdriver 0.10.0
+  - Firefox 66.0
   - Firefox 65.0.1
+  - Google Chrome 73.0.3683.86
   - Google Chrome 73.0.3683.75
 - webdriver 0.8.1, 0.9.0, 0.10.0
   - Firefox 65.0


### PR DESCRIPTION
to attackhelicopter/webdriver:0.8.0